### PR TITLE
feat: add spdlog (only to game_simulator.cpp for now)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(TransportSim)
 
-add_compile_options(-std=c++20)
+add_compile_options(-std=c++2a)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 function(build_transportsim_lib src_dir_name)
     file(GLOB SRC_CPP_FILES src/${src_dir_name}/*.cpp)
     list(FILTER SRC_CPP_FILES EXCLUDE REGEX ".*_test.cpp$")
-    message(${SRC_CPP_FILES})
     add_library(transportsim_${src_dir_name} SHARED ${SRC_CPP_FILES})
     target_include_directories(transportsim_${src_dir_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
     install(TARGETS transportsim_${src_dir_name} LIBRARY DESTINATION lib)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 # Prerequisites
 
-sfml
+sfml (libsfml-dev)
+spdlog (libspdlog-dev)
 
 # Contributing
 

--- a/include/base/spatial.h
+++ b/include/base/spatial.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <math.h>
 #include <vector>
+#include <string>
 #include <unordered_map>
 
 namespace world
@@ -42,6 +43,11 @@ namespace world
     {
         strm << pair.first << "," << pair.second;
         return strm;
+    }
+
+    template <typename T, typename U>
+    std::string to_string(const std::pair<T, U> &pair) {
+        return std::to_string(pair.first) + "," + std::to_string(pair.second);
     }
 
     enum BiDirectionality


### PR DESCRIPTION
Currently, the logger doesn't provide a convenient way to try and type cast custom objects to string, and in the docs an << overload is mentioned but it doesn't seem to play nice with std::pair, so we'll need to do some template hackery if we want a more generic solution